### PR TITLE
Add `Not` and `AnyValidator` validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## 1.1.0
+
+### Added
+
+- `Not` and `AnyValidator` validators.
+
+### Fixed
+
+- Incorrect value being passed to `BaseValidator::testValue()` in `BaseValidator::isValid()`. 
+
 ## 1.0.0
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ class Float extends \Alley\Validator\BaseValidator
 }
 ```
 
+## "Any Validator" Chains
+
+`\Alley\Validator\AnyValidator` is like a [validator chain](https://docs.laminas.dev/laminas-validator/validator-chains/) except that it connects the validators with "OR," marking input as valid as soon it passes one of the given validators.
+
+### Basic usage
+
+```php
+<?php
+
+$valid = new \Alley\Validator\AnyValidator([new \Laminas\Validator\LessThan(['max' => 10])]);
+$valid->attach(new \Laminas\Validator\GreaterThan(['min' => 90]));
+
+$valid->isValid(9); // true
+$valid->isValid(99); // true
+$valid->isValid(42); // false
+```
+
 ## Validators
 
 ### `AlwaysValid`
@@ -111,6 +128,26 @@ $valid = new \Alley\Validator\Comparison(
     ]
 );
 $valid->isValid(true); // true
+```
+
+### `Not`
+
+`Alley\Validator\Not` inverts the validity of a given validator. It allows for creating validators that test whether input is, for example, "not one of" in addition to "one of."
+
+#### Supported options
+
+None.
+
+#### Basic usage
+
+```php
+<?php
+
+$origin = new \Alley\Validator\OneOf(['haystack' => ['foo', 'bar']]);
+$valid = new Alley\Validator\Not($origin, 'The input was invalid.');
+
+$valid->isValid('foo'); // false
+$valid->isValid('baz'); // true
 ```
 
 ### `OneOf`

--- a/README.md
+++ b/README.md
@@ -156,9 +156,7 @@ $valid->isValid('baz'); // true
 
 `OneOf` is a simpler version of `\Laminas\Validator\InArray` that accepts only scalar values in the haystack and does only strict comparisons. In return, it produces a friendlier error message that lists the allowed values.
 
-`OneOf` contains a `::create()` named constructor for initializing an instance directly from the haystack.
-
-#### Supported Options
+#### Supported options
 
 The following options are supported for `\Alley\Validator\OneOf`:
 

--- a/src/Alley/Validator/AnyValidator.php
+++ b/src/Alley/Validator/AnyValidator.php
@@ -33,6 +33,16 @@ final class AnyValidator implements Countable, ValidatorInterface
     protected $messages = [];
 
     /**
+     * @param ValidatorInterface[] $validators
+     */
+    public function __construct(array $validators)
+    {
+        foreach ($validators as $validator) {
+            $this->attach($validator);
+        }
+    }
+
+    /**
      * Attach a validator to the end of the chain.
      *
      * @param ValidatorInterface $validator

--- a/src/Alley/Validator/AnyValidator.php
+++ b/src/Alley/Validator/AnyValidator.php
@@ -15,6 +15,7 @@ namespace Alley\Validator;
 
 use Countable;
 use Laminas\Validator\ValidatorInterface;
+use ReturnTypeWillChange;
 
 final class AnyValidator implements Countable, ValidatorInterface
 {
@@ -82,7 +83,7 @@ final class AnyValidator implements Countable, ValidatorInterface
         return $this->messages;
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return \count($this->validators);

--- a/src/Alley/Validator/AnyValidator.php
+++ b/src/Alley/Validator/AnyValidator.php
@@ -71,7 +71,7 @@ final class AnyValidator implements Countable, ValidatorInterface
         }
 
         foreach ($this->validators as $validator) {
-            $this->messages = array_replace($this->validators, $validator->getMessages());
+            $this->messages = array_replace($this->messages, $validator->getMessages());
         }
 
         return false;

--- a/src/Alley/Validator/AnyValidator.php
+++ b/src/Alley/Validator/AnyValidator.php
@@ -60,7 +60,7 @@ final class AnyValidator implements Countable, ValidatorInterface
         $this->messages = [];
 
         if ($this->count() === 0) {
-            // Consistent with \Laminas\Validator\ValidatorChain().
+            // Consistent with `\Laminas\Validator\ValidatorChain()`.
             return true;
         }
 

--- a/src/Alley/Validator/AnyValidator.php
+++ b/src/Alley/Validator/AnyValidator.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the laminas-validator-extensions package.
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Alley\Validator;
+
+use Countable;
+use Laminas\Validator\ValidatorInterface;
+
+final class AnyValidator implements Countable, ValidatorInterface
+{
+    /**
+     * Validator chain.
+     *
+     * @var ValidatorInterface[]
+     */
+    protected array $validators = [];
+
+    /**
+     * Array of validation failure messages.
+     *
+     * @var string[]
+     */
+    protected $messages = [];
+
+    /**
+     * Attach a validator to the end of the chain.
+     *
+     * @param ValidatorInterface $validator
+     * @return self
+     */
+    public function attach(ValidatorInterface $validator)
+    {
+        $this->validators[] = $validator;
+
+        return $this;
+    }
+
+    public function isValid($value)
+    {
+        $this->messages = [];
+
+        if ($this->count() === 0) {
+            // Consistent with \Laminas\Validator\ValidatorChain().
+            return true;
+        }
+
+        foreach ($this->validators as $validator) {
+            if ($validator->isValid($value)) {
+                return true;
+            }
+        }
+
+        foreach ($this->validators as $validator) {
+            $this->messages = array_replace($this->validators, $validator->getMessages());
+        }
+
+        return false;
+    }
+
+    public function getMessages()
+    {
+        return $this->messages;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function count()
+    {
+        return \count($this->validators);
+    }
+}

--- a/src/Alley/Validator/BaseValidator.php
+++ b/src/Alley/Validator/BaseValidator.php
@@ -20,7 +20,7 @@ abstract class BaseValidator extends AbstractValidator
     final public function isValid($value): bool
     {
         $this->setValue($value);
-        $this->testValue($value);
+        $this->testValue($this->value);
         return \count($this->getMessages()) === 0;
     }
 

--- a/src/Alley/Validator/Not.php
+++ b/src/Alley/Validator/Not.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the laminas-validator-extensions package.
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Alley\Validator;
+
+use Laminas\Validator\ValidatorInterface;
+
+final class Not implements ValidatorInterface
+{
+    private ValidatorInterface $origin;
+
+    private string $message;
+
+    public function __construct(ValidatorInterface $origin, string $message)
+    {
+        $this->origin = $origin;
+        $this->message = $message;
+    }
+
+    public function isValid($value)
+    {
+        return !$this->origin->isValid($value);
+    }
+
+    public function getMessages()
+    {
+        $messages = [];
+
+        if (\count($this->origin->getMessages()) === 0) {
+            $messages[] = $this->message;
+        }
+
+        return $messages;
+    }
+}

--- a/tests/Alley/Validator/AnyValidatorTest.php
+++ b/tests/Alley/Validator/AnyValidatorTest.php
@@ -20,29 +20,28 @@ final class AnyValidatorTest extends TestCase
 {
     public function testNoValidators()
     {
-        $validator = new AnyValidator();
+        $validator = new AnyValidator([]);
         $this->assertTrue($validator->isValid(42));
     }
 
     public function testValidValidator()
     {
-        $validator = new AnyValidator();
-        $validator->attach(new AlwaysValid());
+        $validator = new AnyValidator([new AlwaysValid()]);
         $this->assertTrue($validator->isValid(42));
     }
 
     public function testInvalidValidator()
     {
-        $validator = new AnyValidator();
-        $validator->attach(new GreaterThan(['min' => 43]));
+        $validator = new AnyValidator([new GreaterThan(['min' => 43])]);
         $this->assertFalse($validator->isValid(42));
     }
 
     public function testFirstValidValidator()
     {
-        $validator = new AnyValidator();
-        $validator->attach(new AlwaysValid());
-        $validator->attach(new GreaterThan(['min' => 43]));
+        $validator = new AnyValidator([
+            new AlwaysValid(),
+            new GreaterThan(['min' => 43]),
+        ]);
         $this->assertTrue($validator->isValid(42));
     }
 }

--- a/tests/Alley/Validator/AnyValidatorTest.php
+++ b/tests/Alley/Validator/AnyValidatorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the laminas-validator-extensions package.
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Alley\Validator;
+
+use Laminas\Validator\GreaterThan;
+use PHPUnit\Framework\TestCase;
+
+final class AnyValidatorTest extends TestCase
+{
+    public function testNoValidators()
+    {
+        $validator = new AnyValidator();
+        $this->assertTrue($validator->isValid(42));
+    }
+
+    public function testValidValidator()
+    {
+        $validator = new AnyValidator();
+        $validator->attach(new AlwaysValid());
+        $this->assertTrue($validator->isValid(42));
+    }
+
+    public function testInvalidValidator()
+    {
+        $validator = new AnyValidator();
+        $validator->attach(new GreaterThan(['min' => 43]));
+        $this->assertFalse($validator->isValid(42));
+    }
+
+    public function testFirstValidValidator()
+    {
+        $validator = new AnyValidator();
+        $validator->attach(new AlwaysValid());
+        $validator->attach(new GreaterThan(['min' => 43]));
+        $this->assertTrue($validator->isValid(42));
+    }
+}

--- a/tests/Alley/Validator/NotTest.php
+++ b/tests/Alley/Validator/NotTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the laminas-validator-extensions package.
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Alley\Validator;
+
+use PHPUnit\Framework\TestCase;
+
+final class NotTest extends TestCase
+{
+    public function testNegation()
+    {
+        $origin = new AlwaysValid();
+        $actual = new Not($origin, 'foo');
+        $value = 42;
+        $this->assertNotSame($actual->isValid($value), $origin->isValid($value));
+        $this->assertCount(1, $actual->getMessages());
+    }
+}


### PR DESCRIPTION
## Summary

As titled. These changes are being made in support of https://github.com/alleyinteractive/wp-match-blocks.

## Notes for reviewers

None.

## Changelog entries

### Added

- `Not` and `AnyValidator` validators.

### Changed

### Deprecated

### Removed

### Fixed

- Incorrect value being passed to `BaseValidator::testValue()` in `BaseValidator::isValid()`. 

### Security
