### PR TITLE
Don't return messages if origin validator hasn't been used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Added
 
-- `DivisibleBy` and `FastValidatorChain` validators.
+- `DivisibleBy`, `FastValidatorChain`, and `WithMessage` validators.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Fixed
 
-- `Not` returned error messages before first call to `::isValid()`.
+- `Not::getMessages()` returned failure messages before first call to `::isValid()`.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 - `ContainsString`, `DivisibleBy`, `FastValidatorChain`, `ValidatorByOperator`, and `WithMessage` validators.
 
+### Changed
+
+- The failure message returned by `Not::getMessages()` now has the identifier `notValid`.
+
 ### Fixed
 
 - `Not::getMessages()` returned failure messages before first call to `::isValid()`.
+- `Not::getMessages()` returned an indexed array of messages.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Added
 
-- `ContainsString`, `DivisibleBy`, `FastValidatorChain`, and `WithMessage` validators.
+- `ContainsString`, `DivisibleBy`, `FastValidatorChain`, `ValidatorByOperator`, and `WithMessage` validators.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 - `DivisibleBy` and `FastValidatorChain` validators.
 
+### Fixed
+
+- `Not` returned error messages before first call to `::isValid()`.
+
 ## 1.1.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 - `Not::getMessages()` returned failure messages before first call to `::isValid()`.
 - `Not::getMessages()` returned an indexed array of messages.
+- `Comparison` and `Type` referenced incorrect failure message keys when validating options.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Added
 
-- `DivisibleBy`, `FastValidatorChain`, and `WithMessage` validators.
+- `ContainsString`, `DivisibleBy`, `FastValidatorChain`, and `WithMessage` validators.
 
 ### Fixed
 
-- `Not` returned error messages before first call to `::isValid()`.
+- `Not::getMessages()` returned failure messages before first call to `::isValid()`.
 
 ## 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,26 @@ $valid = new \Alley\Validator\Type(['type' => 'bool']);
 $valid->isValid([]); // false
 ```
 
+### `WithMessage`
+
+`Alley\Validator\WithMessage` allows you to decorate a validator with a custom failure code and message, replacing the validator's usual failure messages.
+
+#### Supported options
+
+None.
+
+#### Basic usage
+
+```php
+<?php
+
+$origin = new \Laminas\Validator\GreaterThan(42);
+$valid = new Alley\Validator\WithMessage('tooSmall', 'Please enter a number greater than 42.', $origin);
+
+$valid->isValid(41); // false
+$valid->getMessages(); // ['tooSmall' => 'Please enter a number greater than 42.']
+```
+
 ## About
 
 ### License

--- a/README.md
+++ b/README.md
@@ -104,6 +104,52 @@ $valid->isValid(42); // false
 count($valid->getMessages()); // 1
 ```
 
+## Validators by operator name
+
+`\Alley\Validator\ValidatorByOperator` allows you to access a validator using a readable operator name, such as `REGEX` or `NOT IN`.
+
+Its primary use case is to allow you to write functions that accept the readable operator names as parameters while using validators internally. Here's a demonstrative function call from [the wp-match-blocks library](https://github.com/alleyinteractive/wp-match-blocks):
+
+```php
+<?php
+
+$images = \Alley\WP\match_blocks(
+    $post,
+    [
+        'name' => 'core/image',
+        'attrs' => [
+            [
+                'key' => 'credit',
+                'value' => '/(The )?Associated Press/i',
+                'operator' => 'REGEX',
+            ],
+        ],
+    ],
+);
+```
+
+The supported operator names are:
+
+* `CONTAINS` and `NOT CONTAINS`, which forward to `\Alley\Validator\ContainsString`.
+* `IN` and `NOT IN`, which forward to `\Alley\Validator\OneOf`.
+* `REGEX` and `NOT REGEX`, which forward to `\Laminas\Validator\Regex`.
+* `===`, `!==`, and the other operators supported by `\Alley\Validator\Comparison`.
+
+Any operator name that isn't forwarded to a different validator must be a valid `Comparison` operator.
+
+### Basic usage
+
+```php
+$valid = new \Alley\Validator\ValidatorByOperator('REGEX', '/^foo/');
+$valid->isValid('foobar'); // true
+
+$valid = new \Alley\Validator\ValidatorByOperator('NOT IN', ['bar', 'baz']);
+$valid->isValid('bar'); // false
+
+$valid = new \Alley\Validator\ValidatorByOperator('!==', 42);
+$valid->isValid(43); // true
+```
+
 ## Validators
 
 ### `AlwaysValid`

--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ $images = \Alley\WP\match_blocks(
 
 The supported operator names are:
 
-* `CONTAINS` and `NOT CONTAINS`, which forward to `\Alley\Validator\ContainsString`.
+* `CONTAINS` and `NOT CONTAINS`, which forward to `\Alley\Validator\ContainsString` using a case-sensitive search.
 * `IN` and `NOT IN`, which forward to `\Alley\Validator\OneOf`.
+* `LIKE` and `NOT LIKE`, which forward to `\Alley\Validator\ContainsString` using a case-insensitive search.
 * `REGEX` and `NOT REGEX`, which forward to `\Laminas\Validator\Regex`.
 * `===`, `!==`, and the other operators supported by `\Alley\Validator\Comparison`.
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ None.
 <?php
 
 $origin = new \Alley\Validator\OneOf(['haystack' => ['foo', 'bar']]);
-$valid = new Alley\Validator\Not($origin, 'The input was invalid.');
+$valid = new \Alley\Validator\Not($origin, 'The input was invalid.');
 
 $valid->isValid('foo'); // false
 $valid->isValid('baz'); // true
@@ -336,7 +336,7 @@ None.
 <?php
 
 $origin = new \Laminas\Validator\GreaterThan(42);
-$valid = new Alley\Validator\WithMessage('tooSmall', 'Please enter a number greater than 42.', $origin);
+$valid = new \Alley\Validator\WithMessage('tooSmall', 'Please enter a number greater than 42.', $origin);
 
 $valid->isValid(41); // false
 $valid->getMessages(); // ['tooSmall' => 'Please enter a number greater than 42.']

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ $valid->isValid(true); // true
 The following options are supported for `\Alley\Validator\ContainsString`:
 
 - `needle`: The string or instance of `\Stringable` the inputs are searched for. It will automatically be cast to a string at the time of validation.
+- `ignoreCase`: Whether to perform a case-insensitive search. False by default.
 
 #### Basic usage
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,31 @@ $valid = new \Alley\Validator\Comparison(
 $valid->isValid(true); // true
 ```
 
+### `ContainsString`
+
+`\Alley\Validator\ContainsString` is a validator around the `str_contains()` function. Each instance of the validator represents the "needle" string and validates whether the string is found within the input "haystack."  Inputs will automatically be cast to strings.
+
+#### Supported options
+
+The following options are supported for `\Alley\Validator\ContainsString`:
+
+- `needle`: The string or instance of `\Stringable` the inputs are searched for. It will automatically be cast to a string at the time of validation.
+
+#### Basic usage
+
+```php
+<?php
+
+$valid = new \Alley\Validator\ContainsString(
+    [
+        'needle' => 'foo',
+    ],
+);
+
+$valid->isValid('foobar'); // true
+$valid->isValid('barbaz'); // false
+```
+
 ### `DivisibleBy`
 
 `\Alley\Validator\DivisibleBy` allows you to validate whether the input is evenly divisible by a given numeric value. Inputs will automatically be cast to integers.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
   },
   "require": {
     "php": "^7.4 || ^8.0",
-    "laminas/laminas-validator": "^2.20"
+    "laminas/laminas-validator": "^2.20",
+    "symfony/polyfill-php80": "^1.26"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.8",

--- a/src/Alley/Validator/Comparison.php
+++ b/src/Alley/Validator/Comparison.php
@@ -112,7 +112,8 @@ final class Comparison extends BaseValidator
         $valid = $this->operatorOptionValidator->isValid($operator);
 
         if (! $valid) {
-            throw new InvalidArgumentException($this->operatorOptionValidator->getMessages()[0]);
+            $messages = $this->operatorOptionValidator->getMessages();
+            throw new InvalidArgumentException("Invalid 'operator': " . current($messages));
         }
 
         $this->options['operator'] = $operator;

--- a/src/Alley/Validator/ContainsString.php
+++ b/src/Alley/Validator/ContainsString.php
@@ -31,6 +31,7 @@ final class ContainsString extends BaseValidator
 
     protected $options = [
         'needle' => '',
+        'ignoreCase' => false,
     ];
 
     private ValidatorInterface $validNeedles;
@@ -52,7 +53,15 @@ final class ContainsString extends BaseValidator
 
     protected function testValue($value): void
     {
-        if (! str_contains((string) $value, (string) $this->options['needle'])) {
+        $haystack = (string) $value;
+        $needle = (string) $this->options['needle'];
+
+        if ($this->options['ignoreCase']) {
+            $haystack = strtolower($haystack);
+            $needle = strtolower($needle);
+        }
+
+        if (! str_contains($haystack, $needle)) {
             $this->error(self::NOT_CONTAINS_STRING);
         }
     }

--- a/src/Alley/Validator/ContainsString.php
+++ b/src/Alley/Validator/ContainsString.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the laminas-validator-extensions package.
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Alley\Validator;
+
+use Laminas\Validator\Exception\InvalidArgumentException;
+use Laminas\Validator\IsInstanceOf;
+use Laminas\Validator\ValidatorInterface;
+
+final class ContainsString extends BaseValidator
+{
+    public const NOT_CONTAINS_STRING = 'notContainsString';
+
+    protected $messageTemplates = [
+        self::NOT_CONTAINS_STRING => 'Must contain string "%needle%".',
+    ];
+
+    protected $messageVariables = [
+        'needle' => ['options' => 'needle'],
+    ];
+
+    protected $options = [
+        'needle' => '',
+    ];
+
+    private ValidatorInterface $validNeedles;
+
+    public function __construct($options)
+    {
+        $this->validNeedles = new WithMessage(
+            'noMatchingTypes',
+            'Must be string or instance of \Stringable',
+            new AnyValidator([
+                new Type([ 'type' => 'string' ]),
+                new IsInstanceOf(\Stringable::class),
+                new Type([ 'type' => 'null' ]),
+            ]),
+        );
+
+        parent::__construct($options);
+    }
+
+    protected function testValue($value): void
+    {
+        if (! str_contains((string) $value, (string) $this->options['needle'])) {
+            $this->error(self::NOT_CONTAINS_STRING);
+        }
+    }
+
+    protected function setNeedle($needle)
+    {
+        $valid = $this->validNeedles->isValid($needle);
+
+        if (! $valid) {
+            $messages = $this->validNeedles->getMessages();
+            throw new InvalidArgumentException("Invalid 'needle': " . current($messages));
+        }
+
+        $this->options['needle'] = $needle;
+    }
+}

--- a/src/Alley/Validator/Not.php
+++ b/src/Alley/Validator/Not.php
@@ -17,6 +17,8 @@ use Laminas\Validator\ValidatorInterface;
 
 final class Not implements ValidatorInterface
 {
+    public const NOT_VALID = 'notValid';
+
     private ValidatorInterface $origin;
 
     private string $message;
@@ -40,7 +42,7 @@ final class Not implements ValidatorInterface
         $messages = [];
 
         if ($this->ran && \count($this->origin->getMessages()) === 0) {
-            $messages[] = $this->message;
+            $messages[self::NOT_VALID] = $this->message;
         }
 
         return $messages;

--- a/src/Alley/Validator/Not.php
+++ b/src/Alley/Validator/Not.php
@@ -21,6 +21,8 @@ final class Not implements ValidatorInterface
 
     private string $message;
 
+    private bool $ran = false;
+
     public function __construct(ValidatorInterface $origin, string $message)
     {
         $this->origin = $origin;
@@ -29,6 +31,7 @@ final class Not implements ValidatorInterface
 
     public function isValid($value)
     {
+        $this->ran = true;
         return !$this->origin->isValid($value);
     }
 
@@ -36,7 +39,7 @@ final class Not implements ValidatorInterface
     {
         $messages = [];
 
-        if (\count($this->origin->getMessages()) === 0) {
+        if ($this->ran && \count($this->origin->getMessages()) === 0) {
             $messages[] = $this->message;
         }
 

--- a/src/Alley/Validator/Type.php
+++ b/src/Alley/Validator/Type.php
@@ -116,7 +116,8 @@ final class Type extends BaseValidator
         $valid = $this->typeOptionValidator->isValid($type);
 
         if (! $valid) {
-            throw new InvalidArgumentException($this->typeOptionValidator->getMessages()[0]);
+            $messages = $this->typeOptionValidator->getMessages();
+            throw new InvalidArgumentException("Invalid 'type': " . current($messages));
         }
 
         $this->options['type'] = $type;

--- a/src/Alley/Validator/ValidatorByOperator.php
+++ b/src/Alley/Validator/ValidatorByOperator.php
@@ -43,6 +43,7 @@ final class ValidatorByOperator implements ValidatorInterface
             case 'NOT CONTAINS':
                 $validator = new ContainsString([
                     'needle' => $param,
+                    'ignoreCase' => false,
                 ]);
                 break;
 
@@ -50,6 +51,14 @@ final class ValidatorByOperator implements ValidatorInterface
             case 'NOT IN':
                 $validator = new OneOf([
                     'haystack' => $param,
+                ]);
+                break;
+
+            case 'LIKE':
+            case 'NOT LIKE':
+                $validator = new ContainsString([
+                    'needle' => $param,
+                    'ignoreCase' => true,
                 ]);
                 break;
 
@@ -67,7 +76,7 @@ final class ValidatorByOperator implements ValidatorInterface
                 ]);
         }
 
-        if ($operator === 'NOT REGEX' || $operator === 'NOT IN' || $operator === 'NOT CONTAINS') {
+        if (str_starts_with($operator, 'NOT ')) {
             $validator = new Not($validator, 'Invalid comparison.');
         }
 

--- a/src/Alley/Validator/ValidatorByOperator.php
+++ b/src/Alley/Validator/ValidatorByOperator.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the laminas-validator-extensions package.
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Alley\Validator;
+
+use Laminas\Validator\Regex;
+use Laminas\Validator\ValidatorInterface;
+
+final class ValidatorByOperator implements ValidatorInterface
+{
+    private ValidatorInterface $final;
+
+    public function __construct(string $operator, $param)
+    {
+        // Build validator now so that its constructor runs, just as if the validator had been instantiated directly.
+        $this->final = $this->validator($operator, $param);
+    }
+
+    public function isValid($value)
+    {
+        return $this->final->isValid($value);
+    }
+
+    public function getMessages()
+    {
+        return $this->final->getMessages();
+    }
+
+    private function validator(string $operator, $param)
+    {
+        switch ($operator) {
+            case 'CONTAINS':
+            case 'NOT CONTAINS':
+                $validator = new ContainsString([
+                    'needle' => $param,
+                ]);
+                break;
+
+            case 'IN':
+            case 'NOT IN':
+                $validator = new OneOf([
+                    'haystack' => $param,
+                ]);
+                break;
+
+            case 'REGEX':
+            case 'NOT REGEX':
+                $validator = new Regex([
+                    'pattern' => $param,
+                ]);
+                break;
+
+            default:
+                $validator = new Comparison([
+                    'operator' => $operator,
+                    'compared' => $param,
+                ]);
+        }
+
+        if ($operator === 'NOT REGEX' || $operator === 'NOT IN' || $operator === 'NOT CONTAINS') {
+            $validator = new Not($validator, 'Invalid comparison.');
+        }
+
+        return $validator;
+    }
+}

--- a/src/Alley/Validator/WithMessage.php
+++ b/src/Alley/Validator/WithMessage.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the laminas-validator-extensions package.
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Alley\Validator;
+
+use Laminas\Validator\ValidatorInterface;
+
+final class WithMessage implements ValidatorInterface
+{
+    private string $code;
+
+    private string $message;
+
+    private ValidatorInterface $origin;
+
+    public function __construct(string $code, string $message, ValidatorInterface $origin)
+    {
+        $this->origin = $origin;
+        $this->code = $code;
+        $this->message = $message;
+    }
+
+    public function isValid($value)
+    {
+        return $this->origin->isValid($value);
+    }
+
+    public function getMessages()
+    {
+        $messages = [];
+
+        if (\count($this->origin->getMessages()) > 0) {
+            $messages[$this->code] = $this->message;
+        }
+
+        return $messages;
+    }
+}

--- a/tests/Alley/Validator/ComparisonTest.php
+++ b/tests/Alley/Validator/ComparisonTest.php
@@ -167,4 +167,13 @@ final class ComparisonTest extends TestCase
             ],
         ];
     }
+
+    public function testInvalidOperator()
+    {
+        $operator = 'foo';
+
+        $this->expectExceptionMessageMatches("/^Invalid 'operator': .+? but is {$operator}\.$/");
+
+        new Comparison([ 'operator' => $operator ]);
+    }
 }

--- a/tests/Alley/Validator/ContainsStringTest.php
+++ b/tests/Alley/Validator/ContainsStringTest.php
@@ -19,7 +19,14 @@ final class ContainsStringTest extends TestCase
 {
     public function testValidInput()
     {
-        $validator = new ContainsString(['needle' => 'foo']);
+        $validator = new ContainsString(['needle' => 'Foo']);
+        $this->assertTrue($validator->isValid('Foobar'));
+        $this->assertFalse($validator->isValid('foobar'));
+    }
+
+    public function testIgnoreCase() {
+        $validator = new ContainsString(['needle' => 'foo', 'ignoreCase' => true]);
+        $this->assertTrue($validator->isValid('Foobar'));
         $this->assertTrue($validator->isValid('foobar'));
     }
 

--- a/tests/Alley/Validator/ContainsStringTest.php
+++ b/tests/Alley/Validator/ContainsStringTest.php
@@ -24,7 +24,8 @@ final class ContainsStringTest extends TestCase
         $this->assertFalse($validator->isValid('foobar'));
     }
 
-    public function testIgnoreCase() {
+    public function testIgnoreCase()
+    {
         $validator = new ContainsString(['needle' => 'foo', 'ignoreCase' => true]);
         $this->assertTrue($validator->isValid('Foobar'));
         $this->assertTrue($validator->isValid('foobar'));

--- a/tests/Alley/Validator/ContainsStringTest.php
+++ b/tests/Alley/Validator/ContainsStringTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the laminas-validator-extensions package.
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Alley\Validator;
+
+use PHPUnit\Framework\TestCase;
+
+final class ContainsStringTest extends TestCase
+{
+    public function testValidInput()
+    {
+        $validator = new ContainsString(['needle' => 'foo']);
+        $this->assertTrue($validator->isValid('foobar'));
+    }
+
+    public function testInvalidInput()
+    {
+        $validator = new ContainsString(['needle' => 'baz']);
+        $this->assertFalse($validator->isValid('foobar'));
+        $this->assertSame(
+            ['notContainsString' => 'Must contain string "baz".'],
+            $validator->getMessages(),
+        );
+    }
+}

--- a/tests/Alley/Validator/NotTest.php
+++ b/tests/Alley/Validator/NotTest.php
@@ -25,4 +25,10 @@ final class NotTest extends TestCase
         $this->assertNotSame($actual->isValid($value), $origin->isValid($value));
         $this->assertCount(1, $actual->getMessages());
     }
+
+    public function testNoMessagesBeforeValidation()
+    {
+        $validator = new Not(new AlwaysValid(), 'foo');
+        $this->assertCount(0, $validator->getMessages());
+    }
 }

--- a/tests/Alley/Validator/TypeTest.php
+++ b/tests/Alley/Validator/TypeTest.php
@@ -155,4 +155,13 @@ final class TypeTest extends TestCase
             ],
         ];
     }
+
+    public function testInvalidType()
+    {
+        $type = 'foo';
+
+        $this->expectExceptionMessageMatches("/^Invalid 'type': .+? but is {$type}\.$/");
+
+        new Type([ 'type' => $type ]);
+    }
 }

--- a/tests/Alley/Validator/ValidatorByOperatorTest.php
+++ b/tests/Alley/Validator/ValidatorByOperatorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the laminas-validator-extensions package.
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Alley\Validator;
+
+use PHPUnit\Framework\TestCase;
+
+final class ValidatorByOperatorTest extends TestCase
+{
+    /**
+     * @dataProvider dataValidInput
+     */
+    public function testValidInput(string $operator, $compared, $value)
+    {
+        $validator = new ValidatorByOperator($operator, $compared);
+        $this->assertTrue($validator->isValid($value));
+    }
+
+    public function dataValidInput()
+    {
+        return [
+            ['REGEX', '/^foo$/', 'foo'],
+            ['NOT REGEX', '/^foo$/', 'foo bar'],
+            ['IN', ['foo', 'bar'], 'foo'],
+            ['NOT IN', ['foo', 'bar'], 'baz'],
+            ['CONTAINS', 'foo', 'foobar'],
+            ['NOT CONTAINS', 'foo', 'barbaz'],
+            ['===', 42, 42],
+        ];
+    }
+
+    /**
+     * @dataProvider dataInvalidInput
+     */
+    public function testInvalidInput(string $operator, $compared, $value)
+    {
+        $validator = new ValidatorByOperator($operator, $compared);
+        $this->assertFalse($validator->isValid($value));
+    }
+
+    public function dataInvalidInput()
+    {
+        return [
+            ['REGEX', '/^foo$/', 'foo bar'],
+            ['NOT REGEX', '/^foo$/', 'foo'],
+            ['IN', ['foo', 'bar'], 'baz'],
+            ['NOT IN', ['foo', 'bar'], 'foo'],
+            ['CONTAINS', 'foo', 'barbaz'],
+            ['NOT CONTAINS', 'foo', 'foobar'],
+            ['===', 42, 43],
+        ];
+    }
+}

--- a/tests/Alley/Validator/ValidatorByOperatorTest.php
+++ b/tests/Alley/Validator/ValidatorByOperatorTest.php
@@ -34,7 +34,9 @@ final class ValidatorByOperatorTest extends TestCase
             ['IN', ['foo', 'bar'], 'foo'],
             ['NOT IN', ['foo', 'bar'], 'baz'],
             ['CONTAINS', 'foo', 'foobar'],
-            ['NOT CONTAINS', 'foo', 'barbaz'],
+            ['NOT CONTAINS', 'foo', 'Foobar'],
+            ['LIKE', 'foo', 'Foobar'],
+            ['NOT LIKE', 'foo', 'barbaz'],
             ['===', 42, 42],
         ];
     }
@@ -57,6 +59,8 @@ final class ValidatorByOperatorTest extends TestCase
             ['NOT IN', ['foo', 'bar'], 'foo'],
             ['CONTAINS', 'foo', 'barbaz'],
             ['NOT CONTAINS', 'foo', 'foobar'],
+            ['LIKE', 'foo', 'barbaz'],
+            ['NOT LIKE', 'foo', 'Foobar'],
             ['===', 42, 43],
         ];
     }

--- a/tests/Alley/Validator/WithMessageTest.php
+++ b/tests/Alley/Validator/WithMessageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the laminas-validator-extensions package.
+ *
+ * (c) Alley <info@alley.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Alley\Validator;
+
+use PHPUnit\Framework\TestCase;
+
+final class WithMessageTest extends TestCase
+{
+    public function testUsesCustomMessage()
+    {
+        $code = 'bar';
+        $message = 'baz';
+        $validator = new WithMessage(
+            $code,
+            $message,
+            new Not(new AlwaysValid(), 'foo'),
+        );
+        $this->assertFalse($validator->isValid('bat'));
+        $this->assertSame([$code => $message], $validator->getMessages());
+    }
+
+    public function testNoMessageWhenValid()
+    {
+        $validator = new WithMessage(
+            'foo',
+            'bar',
+            new AlwaysValid(),
+        );
+        $this->assertTrue($validator->isValid('baz'));
+        $this->assertCount(0, $validator->getMessages());
+    }
+}


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

### Deprecated

### Removed

### Fixed

- `Not::getMessages()` returned failure messages before first call to `::isValid()`.

### Security
