### PR TITLE
Fix failure message bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 - `ContainsString`, `DivisibleBy`, `FastValidatorChain`, `ValidatorByOperator`, and `WithMessage` validators.
 
+### Changed
+
+- The failure message returned by `Not::getMessages()` now has the identifier `notValid`.
+
 ### Fixed
 
 - `Not::getMessages()` returned failure messages before first call to `::isValid()`.
+- `Not::getMessages()` returned an indexed array of messages.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 - `Not::getMessages()` returned failure messages before first call to `::isValid()`.
 - `Not::getMessages()` returned an indexed array of messages.
+- `Comparison` and `Type` referenced incorrect failure message keys when validating options.
 
 ## 1.1.0
 

--- a/src/Alley/Validator/Comparison.php
+++ b/src/Alley/Validator/Comparison.php
@@ -112,7 +112,8 @@ final class Comparison extends BaseValidator
         $valid = $this->operatorOptionValidator->isValid($operator);
 
         if (! $valid) {
-            throw new InvalidArgumentException($this->operatorOptionValidator->getMessages()[0]);
+            $messages = $this->operatorOptionValidator->getMessages();
+            throw new InvalidArgumentException("Invalid 'operator': " . current($messages));
         }
 
         $this->options['operator'] = $operator;

--- a/src/Alley/Validator/Not.php
+++ b/src/Alley/Validator/Not.php
@@ -17,6 +17,8 @@ use Laminas\Validator\ValidatorInterface;
 
 final class Not implements ValidatorInterface
 {
+    public const NOT_VALID = 'notValid';
+
     private ValidatorInterface $origin;
 
     private string $message;
@@ -40,7 +42,7 @@ final class Not implements ValidatorInterface
         $messages = [];
 
         if ($this->ran && \count($this->origin->getMessages()) === 0) {
-            $messages[] = $this->message;
+            $messages[self::NOT_VALID] = $this->message;
         }
 
         return $messages;

--- a/src/Alley/Validator/Type.php
+++ b/src/Alley/Validator/Type.php
@@ -116,7 +116,8 @@ final class Type extends BaseValidator
         $valid = $this->typeOptionValidator->isValid($type);
 
         if (! $valid) {
-            throw new InvalidArgumentException($this->typeOptionValidator->getMessages()[0]);
+            $messages = $this->typeOptionValidator->getMessages();
+            throw new InvalidArgumentException("Invalid 'type': " . current($messages));
         }
 
         $this->options['type'] = $type;

--- a/tests/Alley/Validator/ComparisonTest.php
+++ b/tests/Alley/Validator/ComparisonTest.php
@@ -167,4 +167,13 @@ final class ComparisonTest extends TestCase
             ],
         ];
     }
+
+    public function testInvalidOperator()
+    {
+        $operator = 'foo';
+
+        $this->expectExceptionMessageMatches("/^Invalid 'operator': .+? but is {$operator}\.$/");
+
+        new Comparison([ 'operator' => $operator ]);
+    }
 }

--- a/tests/Alley/Validator/TypeTest.php
+++ b/tests/Alley/Validator/TypeTest.php
@@ -155,4 +155,13 @@ final class TypeTest extends TestCase
             ],
         ];
     }
+
+    public function testInvalidType()
+    {
+        $type = 'foo';
+
+        $this->expectExceptionMessageMatches("/^Invalid 'type': .+? but is {$type}\.$/");
+
+        new Type([ 'type' => $type ]);
+    }
 }


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

- The failure message returned by `Not::getMessages()` now has the identifier `notValid`.

### Deprecated

### Removed

### Fixed

- `Not::getMessages()` returned an indexed array of messages.
- `Comparison` and `Type` referenced incorrect failure message keys when validating options.

### Security
