### PR TITLE
Drop PHP 7.4 support; update Alley domain; mark version 2.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1, 8.0, 7.4 ]
+        php: [ 8.2, 8.1, 8.0 ]
         can_fail: [ false ]
     name: PHP ${{ matrix.php }}
     steps:

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ## Unreleased
 
+Nothing yet.
+
+## 2.0.0
+
 ### Added
 
 - `FreeformValidator` abstract class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 - `Not::getMessages()` returned an indexed array of messages.
 - `Comparison` and `Type` referenced incorrect failure message keys when validating options.
 
+### Removed
+
+- PHP 7.4 support.
+
 ## 1.1.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "authors": [
     {
       "name": "Alley",
-      "email": "info@alley.co"
+      "email": "info@alley.com"
     }
   ],
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,8 @@
     "lock": false
   },
   "require": {
-    "php": "^7.4 || ^8.0",
-    "laminas/laminas-validator": "^2.20",
-    "symfony/polyfill-php80": "^1.26"
+    "php": "^8.0",
+    "laminas/laminas-validator": "^2.20"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.8",

--- a/src/Alley/Validator/AlwaysValid.php
+++ b/src/Alley/Validator/AlwaysValid.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/Validator/AnyValidator.php
+++ b/src/Alley/Validator/AnyValidator.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/Validator/Comparison.php
+++ b/src/Alley/Validator/Comparison.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/Validator/ContainsString.php
+++ b/src/Alley/Validator/ContainsString.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/Validator/DivisibleBy.php
+++ b/src/Alley/Validator/DivisibleBy.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/Validator/ExtendedAbstractValidator.php
+++ b/src/Alley/Validator/ExtendedAbstractValidator.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/Validator/FastFailValidatorChain.php
+++ b/src/Alley/Validator/FastFailValidatorChain.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/Validator/FreeformValidator.php
+++ b/src/Alley/Validator/FreeformValidator.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/Validator/Not.php
+++ b/src/Alley/Validator/Not.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/Validator/OneOf.php
+++ b/src/Alley/Validator/OneOf.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/Validator/Type.php
+++ b/src/Alley/Validator/Type.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/Validator/ValidatorByOperator.php
+++ b/src/Alley/Validator/ValidatorByOperator.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/Validator/WithMessage.php
+++ b/src/Alley/Validator/WithMessage.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/Validator/AnyValidatorTest.php
+++ b/tests/Alley/Validator/AnyValidatorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/Validator/ComparisonTest.php
+++ b/tests/Alley/Validator/ComparisonTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/Validator/ContainsStringTest.php
+++ b/tests/Alley/Validator/ContainsStringTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/Validator/DivisibleByTest.php
+++ b/tests/Alley/Validator/DivisibleByTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/Validator/FastFailValidatorChainTest.php
+++ b/tests/Alley/Validator/FastFailValidatorChainTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/Validator/FreeformValidatorTest.php
+++ b/tests/Alley/Validator/FreeformValidatorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/Validator/NotTest.php
+++ b/tests/Alley/Validator/NotTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/Validator/OneOfTest.php
+++ b/tests/Alley/Validator/OneOfTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/Validator/TypeTest.php
+++ b/tests/Alley/Validator/TypeTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/Validator/ValidatorByOperatorTest.php
+++ b/tests/Alley/Validator/ValidatorByOperatorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/Validator/WithMessageTest.php
+++ b/tests/Alley/Validator/WithMessageTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the laminas-validator-extensions package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

### Deprecated

### Removed

- PHP 7.4 support.

### Fixed

### Security
