### PR TITLE
Reduce use of inner validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ The following options are supported for `\Alley\Validator\OneOf`:
 ```php
 <?php
 
-$valid = \Alley\Validator\OneOf::create(['one', 'two', 'three']);
+$valid = new \Alley\Validator\OneOf(['haystack' => ['one', 'two', 'three']]);
 $valid->isValid('four'); // false
 $valid->getMessages(); // ['notOneOf' => 'Must be one of [one, two, three] but is four.']
 ```

--- a/src/Alley/Validator/Comparison.php
+++ b/src/Alley/Validator/Comparison.php
@@ -62,15 +62,6 @@ final class Comparison extends ExtendedAbstractValidator
         'operator' => '===',
     ];
 
-    private ValidatorInterface $operatorOptionValidator;
-
-    public function __construct($options = null)
-    {
-        $this->operatorOptionValidator = new OneOf(['haystack' => self::SUPPORTED_OPERATORS]);
-
-        parent::__construct($options);
-    }
-
     protected function testValue($value): void
     {
         switch ($this->options['operator']) {
@@ -102,18 +93,15 @@ final class Comparison extends ExtendedAbstractValidator
                 break;
         }
 
-        if (! $result) {
+        if (!$result) {
             $this->error(self::OPERATOR_ERROR_CODES[$this->options['operator']]);
         }
     }
 
     protected function setOperator(string $operator)
     {
-        $valid = $this->operatorOptionValidator->isValid($operator);
-
-        if (! $valid) {
-            $messages = $this->operatorOptionValidator->getMessages();
-            throw new InvalidArgumentException("Invalid 'operator': " . current($messages));
+        if (!\in_array($operator, self::SUPPORTED_OPERATORS, true)) {
+            throw new InvalidArgumentException("Invalid 'operator': {$operator}.");
         }
 
         $this->options['operator'] = $operator;

--- a/src/Alley/Validator/ContainsString.php
+++ b/src/Alley/Validator/ContainsString.php
@@ -34,23 +34,6 @@ final class ContainsString extends ExtendedAbstractValidator
         'ignoreCase' => false,
     ];
 
-    private ValidatorInterface $validNeedles;
-
-    public function __construct($options)
-    {
-        $this->validNeedles = new WithMessage(
-            'noMatchingTypes',
-            'Must be string or instance of \Stringable',
-            new AnyValidator([
-                new Type([ 'type' => 'string' ]),
-                new IsInstanceOf(\Stringable::class),
-                new Type([ 'type' => 'null' ]),
-            ]),
-        );
-
-        parent::__construct($options);
-    }
-
     protected function testValue($value): void
     {
         $haystack = (string) $value;
@@ -61,18 +44,15 @@ final class ContainsString extends ExtendedAbstractValidator
             $needle = strtolower($needle);
         }
 
-        if (! str_contains($haystack, $needle)) {
+        if (!str_contains($haystack, $needle)) {
             $this->error(self::NOT_CONTAINS_STRING);
         }
     }
 
     protected function setNeedle($needle)
     {
-        $valid = $this->validNeedles->isValid($needle);
-
-        if (! $valid) {
-            $messages = $this->validNeedles->getMessages();
-            throw new InvalidArgumentException("Invalid 'needle': " . current($messages));
+        if (!\is_string($needle) && !\is_null($needle) && !$needle instanceof \Stringable) {
+            throw new InvalidArgumentException("Invalid 'needle': Must be string or instance of \Stringable");
         }
 
         $this->options['needle'] = $needle;

--- a/src/Alley/Validator/DivisibleBy.php
+++ b/src/Alley/Validator/DivisibleBy.php
@@ -32,29 +32,12 @@ final class DivisibleBy extends ExtendedAbstractValidator
         'divisor' => 1,
     ];
 
-    private ValidatorInterface $validDivisors;
-
-    private ValidatorInterface $validRemainders;
-
-    public function __construct($options)
-    {
-        $this->validDivisors = new Comparison([
-            'compared' => 0,
-            'operator' => '!==',
-        ]);
-        $this->validRemainders = new Comparison(
-            [
-                'compared' => 0,
-                'operator' => '===',
-            ],
-        );
-
-        parent::__construct($options);
-    }
-
     protected function testValue($value): void
     {
-        if (! $this->validRemainders->isValid((int) $value % $this->options['divisor'])) {
+        $value = (int) $value;
+        $actual = $value % $this->options['divisor'];
+
+        if ($actual !== 0) {
             $this->error(self::NOT_DIVISIBLE_BY);
         }
     }
@@ -62,11 +45,9 @@ final class DivisibleBy extends ExtendedAbstractValidator
     protected function setDivisor($divisor)
     {
         $divisor = (int) $divisor;
-        $valid = $this->validDivisors->isValid($divisor);
 
-        if (! $valid) {
-            $messages = $this->validDivisors->getMessages();
-            throw new InvalidArgumentException("Invalid 'divisor': " . current($messages));
+        if ($divisor === 0) {
+            throw new InvalidArgumentException("Invalid 'divisor': {$divisor}");
         }
 
         $this->options['divisor'] = $divisor;

--- a/src/Alley/Validator/OneOf.php
+++ b/src/Alley/Validator/OneOf.php
@@ -34,31 +34,19 @@ final class OneOf extends ExtendedAbstractValidator
         'haystack' => [],
     ];
 
-    private ValidatorInterface $haystackOptionValidator;
-
-    public function __construct($options = null)
-    {
-        $this->haystackOptionValidator = new Explode([
-            'validator' => new Callback('is_scalar'),
-            'breakOnFirstFailure' => true,
-        ]);
-
-        parent::__construct($options);
-    }
-
     protected function testValue($value): void
     {
-        if (! \in_array($value, $this->options['haystack'], true)) {
+        if (!\in_array($value, $this->options['haystack'], true)) {
             $this->error(self::NOT_ONE_OF);
         }
     }
 
     protected function setHaystack(array $haystack)
     {
-        $valid = $this->haystackOptionValidator->isValid($haystack);
-
-        if (! $valid) {
-            throw new InvalidArgumentException('Haystack must contain only scalar values.');
+        foreach ($haystack as $item) {
+            if (!\is_scalar($item)) {
+                throw new InvalidArgumentException('Haystack must contain only scalar values.');
+            }
         }
 
         $this->options['haystack'] = $haystack;

--- a/src/Alley/Validator/Type.php
+++ b/src/Alley/Validator/Type.php
@@ -51,15 +51,6 @@ final class Type extends ExtendedAbstractValidator
         'type' => 'null',
     ];
 
-    private ValidatorInterface $typeOptionValidator;
-
-    public function __construct($options = null)
-    {
-        $this->typeOptionValidator = new OneOf(['haystack' => self::SUPPORTED_TYPES]);
-
-        parent::__construct($options);
-    }
-
     protected function testValue($value): void
     {
         switch ($this->options['type']) {
@@ -113,11 +104,8 @@ final class Type extends ExtendedAbstractValidator
 
     protected function setType(string $type)
     {
-        $valid = $this->typeOptionValidator->isValid($type);
-
-        if (! $valid) {
-            $messages = $this->typeOptionValidator->getMessages();
-            throw new InvalidArgumentException("Invalid 'type': " . current($messages));
+        if (!\in_array($type, self::SUPPORTED_TYPES, true)) {
+            throw new InvalidArgumentException("Invalid 'type': {$type}.");
         }
 
         $this->options['type'] = $type;

--- a/tests/Alley/Validator/ComparisonTest.php
+++ b/tests/Alley/Validator/ComparisonTest.php
@@ -172,7 +172,7 @@ final class ComparisonTest extends TestCase
     {
         $operator = 'foo';
 
-        $this->expectExceptionMessageMatches("/^Invalid 'operator': .+? but is {$operator}\.$/");
+        $this->expectExceptionMessageMatches("/^Invalid 'operator': {$operator}\.$/");
 
         new Comparison([ 'operator' => $operator ]);
     }

--- a/tests/Alley/Validator/TypeTest.php
+++ b/tests/Alley/Validator/TypeTest.php
@@ -160,7 +160,7 @@ final class TypeTest extends TestCase
     {
         $type = 'foo';
 
-        $this->expectExceptionMessageMatches("/^Invalid 'type': .+? but is {$type}\.$/");
+        $this->expectExceptionMessageMatches("/^Invalid 'type': {$type}\.$/");
 
         new Type([ 'type' => $type ]);
     }


### PR DESCRIPTION
## Summary

Profiling conducted on a recent client project suggests the use of validators within validators becomes relatively slow. This PR removes the use of these inner validators, which makes the code less DRY but should make it more performant.

Since most of the slowdown caused by the inner validators occurred during processing by the abstract validator class, it might be worth considering moving this library's validators away from that abstract validator, making it more palatable to use inner validators again.

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

- Reduce uses of validators within validators.

### Deprecated

### Removed

### Fixed

### Security
