### PR TITLE
Fix array-to-string conversion

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.2, 8.1, 8.0 ]
+        php: [ 8.3, 8.2, 8.1, 8.0 ]
         can_fail: [ false ]
     name: PHP ${{ matrix.php }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 Nothing yet.
 
+## 2.1.1
+
+### Fixed
+
+- Array-to-string conversion in `ContainsString`.
+
 ## 2.1.0
 
 ### Changed

--- a/src/Alley/Validator/ContainsString.php
+++ b/src/Alley/Validator/ContainsString.php
@@ -36,7 +36,7 @@ final class ContainsString extends ExtendedAbstractValidator
 
     protected function testValue($value): void
     {
-        if (is_scalar($value)) {
+        if (\is_scalar($value)) {
             $haystack = (string) $value;
             $needle = (string) $this->options['needle'];
 

--- a/src/Alley/Validator/ContainsString.php
+++ b/src/Alley/Validator/ContainsString.php
@@ -36,17 +36,21 @@ final class ContainsString extends ExtendedAbstractValidator
 
     protected function testValue($value): void
     {
-        $haystack = (string) $value;
-        $needle = (string) $this->options['needle'];
+        if (is_scalar($value)) {
+            $haystack = (string) $value;
+            $needle = (string) $this->options['needle'];
 
-        if ($this->options['ignoreCase']) {
-            $haystack = strtolower($haystack);
-            $needle = strtolower($needle);
+            if ($this->options['ignoreCase']) {
+                $haystack = strtolower($haystack);
+                $needle = strtolower($needle);
+            }
+
+            if (str_contains($haystack, $needle)) {
+                return;
+            }
         }
 
-        if (!str_contains($haystack, $needle)) {
-            $this->error(self::NOT_CONTAINS_STRING);
-        }
+        $this->error(self::NOT_CONTAINS_STRING);
     }
 
     protected function setNeedle($needle)

--- a/tests/Alley/Validator/ContainsStringTest.php
+++ b/tests/Alley/Validator/ContainsStringTest.php
@@ -40,4 +40,14 @@ final class ContainsStringTest extends TestCase
             $validator->getMessages(),
         );
     }
+
+    public function testNonScalar()
+    {
+        $validator = new ContainsString(['needle' => 'baz']);
+        $this->assertFalse($validator->isValid([]));
+        $this->assertSame(
+            ['notContainsString' => 'Must contain string "baz".'],
+            $validator->getMessages(),
+        );
+    }
 }


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

### Fixed

- Array-to-string conversion in `ContainsString`.
